### PR TITLE
DWI-24 continued: Fixes production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   python3-dev \ 
   default-libmysqlclient-dev \ 
   build-essential \ 
-  pkg-config
+  pkg-config \
+  default-mysql-client \
+  vim-tiny
 
 # Set the working directory to /app
 WORKDIR /app
@@ -87,7 +89,8 @@ RUN mkdir -p /venv && chown ${UID}:${GID} /venv
 # By adding /venv/bin to the PATH the dependencies in the virtual environment
 # are used
 ENV VIRTUAL_ENV=/venv \
-    PATH="/venv/bin:$PATH"
+    PATH="/venv/bin:$PATH" \
+    PYTHONPATH="/app"
 
 COPY --chown=${UID}:${GID} . /app
 COPY --chown=${UID}:${GID} --from=build "/app/.venv" ${VIRTUAL_ENV}

--- a/aim/digifeeds/bin/load_statuses.py
+++ b/aim/digifeeds/bin/load_statuses.py
@@ -1,10 +1,12 @@
+import sys
 from aim.digifeeds.database.models import load_statuses
 from aim.digifeeds.database.main import SessionLocal
-import sys
+
 
 def main():
     with SessionLocal() as db_session:
-      load_statuses(session=db_session)
+        load_statuses(session=db_session)
 
-if __name__=='__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/aim/services.py
+++ b/aim/services.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 import os
 
 S = SimpleNamespace()
-S.mysql_database = f'mysql+mysqldb://{os.environ["MARIADB_USER"]}:{os.environ["MARIADB_PASSWORD"]}@{os.environ["DATABASE_HOST"]}/{os.environ["DATABASE_HOST"]}'
+S.mysql_database = f'mysql+mysqldb://{os.environ["MARIADB_USER"]}:{os.environ["MARIADB_PASSWORD"]}@{os.environ["DATABASE_HOST"]}/{os.environ["MARIADB_DATABASE"]}'
 S.test_database = "sqlite:///:memory:"
 S.ci_on = os.getenv("CI")
-


### PR DESCRIPTION
This PR:
    * adds mysql client and vim-tiny to docker file
    * adds `/app` to `PYTHONPATH` env var in production image
    * fixes the `mysql_database` URL to to use the MARIADB_DATABASE env var