### PR TITLE
DWI-29 Fast API Docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "charliermarsh.ruff"
+      },
 }

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -57,7 +57,7 @@ def get_items(
     response_model_by_alias=False,
     responses={
         404: {
-            "description": "Bad request</br></br>The item doesn't exist",
+            "description": "Bad request: The item doesn't exist",
             "model": schemas.Response404,
         }
     },
@@ -84,7 +84,7 @@ def get_item(
     response_model_by_alias=False,
     responses={
         400: {
-            "description": "Bad request</br></br>The item already exists",
+            "description": "Bad request: The item already exists",
             "model": schemas.Response400,
         }
     },
@@ -107,13 +107,21 @@ def create_item(
     db_item = crud.add_item(item=item, db=db)
     return db_item
 
+desc_put_404 = """
+Bad request: The item or status doesn't exist<br><br>
+Possible reponses:
+<ul>
+  <li>Item not found</li>
+  <li>Status not found</li>
+</ul>
+"""
 
 @app.put(
     "/items/{barcode}/status/{status_name}",
     response_model_by_alias=False,
     responses={
         404: {
-            "description": "Bad request</br></br>The item or status doesn't exist",
+            "description": desc_put_404,
             "model": schemas.Response404,
         }
     },
@@ -125,7 +133,7 @@ def update_item(
     """
     Update a digifeeds item.
 
-    The item can be updated with the barcode of the item and the status.
+    This is how to add a status to an existing item.
     """
 
     db_status = crud.get_status(name=status_name, db=db)

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -77,6 +77,12 @@ def create_item(
     barcode: str = Path(..., description="The barcode of the item"),
     db: Session = Depends(get_db),
 ) -> schemas.Item:
+    """
+    Create a digifeeds item.
+
+    The item can be created with the barcode of the item and must not already exist.
+    """
+
     item = schemas.ItemCreate(barcode=barcode)
     db_item = crud.get_item(barcode=item.barcode, db=db)
     if db_item:

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -52,7 +52,17 @@ def get_items(
     return db_items
 
 
-@app.get("/items/{barcode}", response_model_by_alias=False, tags=["Digifeeds Database"])
+@app.get(
+    "/items/{barcode}",
+    response_model_by_alias=False,
+    responses={
+        404: {
+            "description": "Bad request</br></br>The item doesn't exist",
+            "model": schemas.Response404,
+        }
+    },
+    tags=["Digifeeds Database"],
+)
 def get_item(
     barcode: str = Path(..., description="The barcode of the item"),
     db: Session = Depends(get_db),
@@ -78,7 +88,7 @@ def get_item(
             "model": schemas.Response400,
         }
     },
-    tags=["Digifeeds Database"]
+    tags=["Digifeeds Database"],
 )
 def create_item(
     barcode: str = Path(..., description="The barcode of the item"),
@@ -98,7 +108,17 @@ def create_item(
     return db_item
 
 
-@app.put("/items/{barcode}/status/{status_name}", response_model_by_alias=False, tags=["Digifeeds Database"])
+@app.put(
+    "/items/{barcode}/status/{status_name}",
+    response_model_by_alias=False,
+    responses={
+        404: {
+            "description": "Bad request</br></br>The item or status doesn't exist",
+            "model": schemas.Response404,
+        }
+    },
+    tags=["Digifeeds Database"],
+)
 def update_item(
     barcode: str, status_name: str, db: Session = Depends(get_db)
 ) -> schemas.Item:

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -16,6 +16,12 @@ description = """
 The Digifeeds API enables tracking of images sent to HathiTrust and Google
 through the digifeeds workflow
 """
+tags_metadata = [
+    {
+        "name": "Digifeeds Database",
+        "description": "Digifeeds items and statuses.",
+    },
+]
 app = FastAPI(title="Digifeeds", description=description)
 
 
@@ -28,7 +34,7 @@ def get_db():  # pragma: no cover
         db.close()
 
 
-@app.get("/items/", response_model_by_alias=False)
+@app.get("/items/", response_model_by_alias=False, tags=["Digifeeds Database"])
 def get_items(
     in_zephir: bool | None = Query(
         None, description="Filter for items that do or do not have metadata in Zephir"
@@ -46,7 +52,7 @@ def get_items(
     return db_items
 
 
-@app.get("/items/{barcode}", response_model_by_alias=False)
+@app.get("/items/{barcode}", response_model_by_alias=False, tags=["Digifeeds Database"])
 def get_item(
     barcode: str = Path(..., description="The barcode of the item"),
     db: Session = Depends(get_db),
@@ -72,6 +78,7 @@ def get_item(
             "model": schemas.Response400,
         }
     },
+    tags=["Digifeeds Database"]
 )
 def create_item(
     barcode: str = Path(..., description="The barcode of the item"),
@@ -91,7 +98,7 @@ def create_item(
     return db_item
 
 
-@app.put("/items/{barcode}/status/{status_name}", response_model_by_alias=False)
+@app.put("/items/{barcode}/status/{status_name}", response_model_by_alias=False, tags=["Digifeeds Database"])
 def update_item(
     barcode: str, status_name: str, db: Session = Depends(get_db)
 ) -> schemas.Item:
@@ -110,7 +117,7 @@ def update_item(
     return crud.add_item_status(db=db, item=db_item, status=db_status)
 
 
-@app.get("/statuses")
+@app.get("/statuses", tags=["Digifeeds Database"])
 def get_statuses(db: Session = Depends(get_db)) -> list[schemas.Status]:
     """
     Get digifeeds statuses.

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -35,6 +35,13 @@ def get_items(
     ),
     db: Session = Depends(get_db),
 ) -> list[schemas.Item]:
+    """
+    Get the digifeeds items.
+
+    These items can be filtered by whether or not their metadata is in Zephir or
+    all of them can be fetched.
+    """
+
     db_items = crud.get_items(in_zephir=in_zephir, db=db)
     return db_items
 

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -50,7 +50,16 @@ def get_item(
     return db_item
 
 
-@app.post("/items/{barcode}", response_model_by_alias=False)
+@app.post(
+    "/items/{barcode}",
+    response_model_by_alias=False,
+    responses={
+        400: {
+            "description": "Bad request</br></br>The item already exists",
+            "model": schemas.Response400,
+        }
+    },
+)
 def create_item(
     barcode: str = Path(..., description="The barcode of the item"),
     db: Session = Depends(get_db),

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -112,5 +112,11 @@ def update_item(
 
 @app.get("/statuses")
 def get_statuses(db: Session = Depends(get_db)) -> list[schemas.Status]:
+    """
+    Get digifeeds statuses.
+
+    Get a list of statuses.
+    """
+
     db_statuses = crud.get_statuses(db=db)
     return db_statuses

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -11,7 +11,12 @@ else:  # pragma: no cover
     engine = create_engine(S.mysql_database)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-app = FastAPI()
+
+description = """
+The Digifeeds API enables tracking of images sent to HathiTrust and Google
+through the digifeeds workflow
+"""
+app = FastAPI(title="Digifeeds", description=description)
 
 
 # Dependency

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -95,6 +95,12 @@ def create_item(
 def update_item(
     barcode: str, status_name: str, db: Session = Depends(get_db)
 ) -> schemas.Item:
+    """
+    Update a digifeeds item.
+
+    The item can be updated with the barcode of the item and the status.
+    """
+
     db_status = crud.get_status(name=status_name, db=db)
     if db_status is None:
         raise HTTPException(status_code=404, detail="Status not found")

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -51,6 +51,12 @@ def get_item(
     barcode: str = Path(..., description="The barcode of the item"),
     db: Session = Depends(get_db),
 ) -> schemas.Item:
+    """
+    Get a digifeeds item.
+
+    The item can be fetched by the barcode of the item.
+    """
+
     db_item = crud.get_item(barcode=barcode, db=db)
     if db_item is None:
         raise HTTPException(status_code=404, detail="Item not found")

--- a/aim/digifeeds/database/schemas.py
+++ b/aim/digifeeds/database/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, ConfigDict
 from datetime import datetime
 
+
 class ItemStatus(BaseModel):
     name: str = Field(alias="status_name")
     description: str = Field(alias="status_description")
@@ -8,17 +9,38 @@ class ItemStatus(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
+
 class ItemBase(BaseModel):
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     barcode: str = Field(alias="item_barcode")
 
+
 class Item(ItemBase):
     created_at: datetime
     statuses: list[ItemStatus] = []
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "barcode": "39015040218748",
+                    "created_at": "2024-09-25T17:12:39",
+                    "statuses": [
+                        {
+                            "name": "in_zephir",
+                            "description": "Item is in zephir",
+                            "created_at": "2024-09-25T17:13:28",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+
 
 class ItemCreate(ItemBase):
     pass
+
 
 class StatusBase(BaseModel):
     name: str
@@ -26,5 +48,3 @@ class StatusBase(BaseModel):
 
 class Status(StatusBase):
     description: str
-
-

--- a/aim/digifeeds/database/schemas.py
+++ b/aim/digifeeds/database/schemas.py
@@ -59,7 +59,7 @@ class Response400(Response):
         json_schema_extra={
             "examples": [
                 {
-                    "detail": "Item already exists.",
+                    "detail": "Item already exists",
                 }
             ]
         }
@@ -70,7 +70,7 @@ class Response404(Response):
         json_schema_extra={
             "examples": [
                 {
-                    "detail": "Item not found.",
+                    "detail": "Item not found",
                 }
             ]
         }

--- a/aim/digifeeds/database/schemas.py
+++ b/aim/digifeeds/database/schemas.py
@@ -48,3 +48,19 @@ class StatusBase(BaseModel):
 
 class Status(StatusBase):
     description: str
+
+
+class Response(BaseModel):
+    detail: str
+
+
+class Response400(Response):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "detail": "Item already exists.",
+                }
+            ]
+        }
+    )

--- a/aim/digifeeds/database/schemas.py
+++ b/aim/digifeeds/database/schemas.py
@@ -64,3 +64,14 @@ class Response400(Response):
             ]
         }
     )
+
+class Response404(Response):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "detail": "Item not found.",
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
So far this has some breadcrumbs for filling out documentation in FastAPI. 

There's some application metadata changes in `aim/digifeeds/database/main.py`. [Documentation](https://fastapi.tiangolo.com/tutorial/metadata/) 

There's an example item described in `aim/digifeeds/database/schemas.py`. [Documentation](https://fastapi.tiangolo.com/tutorial/schema-extra-example/)

In `main.py` and in `schemas.py` there's example of how to document non-200 responses. [Documentation](https://fastapi.tiangolo.com/advanced/additional-responses/)

In `main.py` there's an example of using a docstring to describe an api path. [Documentation](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/#description-from-docstring)
