### PR TITLE
handles items in digifeeds set in alma that don't yet have a status i…

### DIFF
--- a/aim/digifeeds/add_to_db.py
+++ b/aim/digifeeds/add_to_db.py
@@ -30,6 +30,11 @@ def add_to_db(barcode: str):
                         )
                     )
                 return item
+            elif any(e["errorCode"] == "60115" for e in errorList):
+                # 60115 means the barcode is already in the set. That means the
+                # db entry from this barcdoe needs to have
+                # added_to_digifeeds_set
+                pass
             else:
                 raise ext_inst
         item = Item(

--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -13,7 +13,7 @@ from aim.services import S
 if S.ci_on:  # pragma: no cover
     engine = create_engine(S.test_database)
 else:  # pragma: no cover
-    engine = create_engine(S.mysql_database)
+    engine = create_engine(S.mysql_database, pool_recycle=3600)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
@@ -112,6 +112,7 @@ def create_item(
     db_item = crud.add_item(item=item, db=db)
     return db_item
 
+
 desc_put_404 = """
 Bad request: The item or status doesn't exist<br><br>
 Possible reponses:
@@ -120,6 +121,7 @@ Possible reponses:
   <li>Status not found</li>
 </ul>
 """
+
 
 @app.put(
     "/items/{barcode}/status/{status_name}",

--- a/aim/digifeeds/item.py
+++ b/aim/digifeeds/item.py
@@ -40,6 +40,15 @@ class Item:
 
     @property
     def in_zephir_for_long_enough(self) -> bool:
+        """
+        Returns whether or not the item has had metadata in zephir for more than
+        14 days. The production database saves timestamps in Eastern Time. K8s
+        runs in UTC. Because this is checking days, this function doesn't set the
+        timezone because it's not close enough to matter.
+
+        Returns:
+            bool: whether or not the item's metadata has been in zephir for more than 14 days.
+        """
         waiting_period = 14  # days
         in_zephir_status = next(
             (

--- a/tests/digifeeds/test_add_to_db.py
+++ b/tests/digifeeds/test_add_to_db.py
@@ -24,6 +24,45 @@ def test_add_to_db_barcode_thats_in_the_digifeeds_set(mocker, item_data):
     assert result.barcode == "some_barcode"
 
 
+@responses.activate
+def test_add_to_db_barcode_thats_in_the_digifeeds_set_but_doesnt_have_status(
+    mocker, item_data
+):
+    item_data["statuses"][0]["name"] = "some_other_status"
+    get_item_mock = mocker.patch(
+        "aim.digifeeds.db_client.DBClient.get_or_add_item", return_value=item_data
+    )
+    add_status_mock = mocker.patch(
+        "aim.digifeeds.db_client.DBClient.add_item_status", return_value=item_data
+    )
+    error_body = {
+        "errorsExist": True,
+        "errorList": {
+            "error": [
+                {
+                    "errorCode": "60115",
+                    "errorMessage": "The following ID(s) are already in the set ['some_barcode']",
+                    "trackingId": "E01-2609211329-8EKLP-AWAE1781893571",
+                }
+            ]
+        },
+    }
+    add_to_digifeeds_url = f"{S.alma_api_url}/conf/sets/{S.digifeeds_set_id}"
+    add_to_digifeeds_set = responses.post(
+        add_to_digifeeds_url,
+        json=error_body,
+        status=400,
+    )
+
+    result = add_to_db("some_barcode")
+    get_item_mock.assert_called_once()
+    add_status_mock.assert_called_once_with(
+        barcode="some_barcode", status="added_to_digifeeds_set"
+    )
+    assert add_to_digifeeds_set.call_count == 1
+    assert result.barcode == "some_barcode"
+
+
 def test_add_to_db_barcode_thats_not_in_the_digifeeds_set(mocker, item_data):
     item_data["statuses"][0]["name"] = "some_other_status"
     get_item_mock = mocker.patch(


### PR DESCRIPTION
This PR includes:

* handling attempting to add items to the alma digifeeds set that are already there
* adding pool_recycle for mysql so that it doesn't have the `Server has gone away` error.
* adds some documentation about why the `in_zephir_for_long_enough` method does not set the timezone.