### PR TITLE
lowering the pool_recycle time

### DIFF
--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -13,7 +13,7 @@ from aim.services import S
 if S.ci_on:  # pragma: no cover
     engine = create_engine(S.test_database)
 else:  # pragma: no cover
-    engine = create_engine(S.mysql_database, pool_recycle=3600)
+    engine = create_engine(S.mysql_database, pool_recycle=1800)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
Lowers the pool_recycle time in the hope that we don't get:
```
sqlalchemy.exc.OperationalError: (MySQLdb.OperationalError) (2006, 'Server has gone away')
```