### PR TITLE
Change to Pessimistic pool_pre_ping

### DIFF
--- a/aim/digifeeds/database/main.py
+++ b/aim/digifeeds/database/main.py
@@ -14,7 +14,7 @@ from aim.services import S
 if S.ci_on:  # pragma: no cover
     engine = create_engine(S.test_database)
 else:  # pragma: no cover
-    engine = create_engine(S.mysql_database, pool_recycle=1800)
+    engine = create_engine(S.mysql_database, pool_pre_ping=True)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
We had been seeing `(MySQLdb.OperationalError) (2006, 'Server has gone away')`. To deal we are changing from `pool_recycle` to `pool_pre_ping`. 