### PR TITLE
adds hathifiles to continuous integration

### DIFF
--- a/.github/workflows/build-deploy-on-release.yaml
+++ b/.github/workflows/build-deploy-on-release.yaml
@@ -21,6 +21,13 @@ jobs:
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
       file: environments/digifeeds/production/app-image.txt
-      CONFIG_REPO_RW_APP_ID: ${{ vars.CONFIG_REPO_RW_APP_ID }}
-      CONFIG_REPO_FULL_NAME: ${{ vars.CONFIG_REPO_FULL_NAME }}
+    secrets: inherit
+
+  deploy-production-hathifiles:
+    needs: build-production
+    name: Deploy to production - hathifiles
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    with:
+      image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+      file: environments/hathifiles/production/cli-image.txt
     secrets: inherit

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -23,6 +23,13 @@ jobs:
     with:
       image: ${{ needs.build-unstable.outputs.image }}
       file: environments/digifeeds/workshop/app-image.txt
-      CONFIG_REPO_RW_APP_ID: ${{ vars.CONFIG_REPO_RW_APP_ID }}
-      CONFIG_REPO_FULL_NAME: ${{ vars.CONFIG_REPO_FULL_NAME }}
+    secrets: inherit
+
+  deploy-workshop-hathifiles:
+    needs: build-unstable
+    name: "Deploy to workshop - hathifiles"
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    with:
+      image: ${{ needs.build-unstable.outputs.image }}
+      file: environments/hathifiles/workshop/cli-image.txt
     secrets: inherit

--- a/.github/workflows/manual-deploy-production.yaml
+++ b/.github/workflows/manual-deploy-production.yaml
@@ -24,6 +24,13 @@ jobs:
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.inputs.tag }}
       file: environments/digifeeds/production/app-image.txt
-      CONFIG_REPO_RW_APP_ID: ${{ vars.CONFIG_REPO_RW_APP_ID }}
-      CONFIG_REPO_FULL_NAME: ${{ vars.CONFIG_REPO_FULL_NAME }}
+    secrets: inherit
+
+  deploy-production-hathifiles:
+    needs: build-production
+    name: Deploy to production - hathifiles
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    with:
+      image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.inputs.tag }}
+      file: environments/hathifiles/production/cli-image.txt
     secrets: inherit

--- a/.github/workflows/manual-deploy-workshop.yaml
+++ b/.github/workflows/manual-deploy-workshop.yaml
@@ -23,6 +23,13 @@ jobs:
     with:
       image: ${{ needs.build-unstable.outputs.image }}
       file: environments/digifeeds/workshop/app-image.txt
-      CONFIG_REPO_RW_APP_ID: ${{ vars.CONFIG_REPO_RW_APP_ID }}
-      CONFIG_REPO_FULL_NAME: ${{ vars.CONFIG_REPO_FULL_NAME }}
+    secrets: inherit
+
+  deploy-workshop-hathifiles:
+    needs: build-unstable
+    name: Deploy to workshop - hathifiles
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    with:
+      image: ${{ needs.build-unstable.outputs.image }}
+      file: environments/hathifiles/workshop/cli-image.txt
     secrets: inherit


### PR DESCRIPTION
This PR adds that hathifiles directory as deployment destination for the `aim-py` image. 

It also gets rid of the explicit references to the github app secret since the workflows can look for variables in vars.