### PR TITLE
Fix upload to s3 script

### DIFF
--- a/bin/digifeeds/upload_to_s3.sh
+++ b/bin/digifeeds/upload_to_s3.sh
@@ -145,34 +145,25 @@ print_metrics() {
     fp_last=$(last_count $fp_metric)
     local fp_total=$((fp_last + fp_current_total))
 
-    local image_order_errors_metric="${JOB_NAME}_image_order_errors_total"
-    local image_order_errors_last
-    image_order_errors_last=$(last_count $image_order_errors_metric)
-    local image_order_errors_total=$((image_order_errors_last + image_order_errors_current_total))
+    local image_order_errors_metric="${JOB_NAME}_image_order_errors"
 
-    local upload_errors_metric="${JOB_NAME}_upload_errors_total"
-    local upload_errors_last
-    upload_errors_last=$(last_count $upload_errors_metric)
-    local upload_errors_total=$((upload_errors_last + upload_errors_current_total))
+    local upload_errors_metric="${JOB_NAME}_upload_errors"
 
-    local errors_metric="${JOB_NAME}_errors_total"
-    local errors_last
-    errors_last=$(last_count $errors_metric)
-    local errors_total=$((errors_last + errors_current_total))
+    local errors_metric="${JOB_NAME}_errors"
 
     cat <<EOMETRICS
 # HELP ${fp_metric} Count of digifeeds zip files sent to S3
 # TYPE ${fp_metric} counter
 $fp_metric $fp_total
-# HELP ${image_order_errors_metric} Count of folders where there are missing pages of images 
-# TYPE ${image_order_errors_metric} counter
-${image_order_errors_metric} $image_order_errors_total
-# HELP ${upload_errors_metric} Count of errors when uploading digifeeds zip files to S3
-# TYPE ${upload_errors_metric} counter
-${upload_errors_metric} $upload_errors_total
-# HELP ${errors_metric} Count of all errors relating ot uploading digifeeds files sent to S3
-# TYPE ${errors_metric} counter
-${errors_metric} $errors_total
+# HELP ${image_order_errors_metric} Number of folders in this run where there are missing pages of images 
+# TYPE ${image_order_errors_metric} gauge
+${image_order_errors_metric} $image_order_errors_current_total
+# HELP ${upload_errors_metric} Number of errors in this run when uploading digifeeds zip files to S3
+# TYPE ${upload_errors_metric} gauge
+${upload_errors_metric} $upload_errors_current_total
+# HELP ${errors_metric} Number of all errors in this run relating ot uploading digifeeds files sent to S3
+# TYPE ${errors_metric} gauge
+${errors_metric} $errors_current_total
 EOMETRICS
 }
 

--- a/bin/digifeeds/upload_to_s3.sh
+++ b/bin/digifeeds/upload_to_s3.sh
@@ -17,20 +17,20 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 APP_ENV=${APP_ENV:-"production"}
 
 if [[ $APP_ENV != "test" ]]; then
-  # CONFIG
-  # Variables contained in the config file:
-  #
-  # input_directory: path to the input directory
-  # working directory: path to nfs directory for doing the zipping and sending
-  # processed_directory: path to the directory  of processed files+%
-  # digifeeds_bucket: rclone remote for the digifeeds bucket
-  #
-  # timestamp: used for testing timestamps; should be ommited in production
-  # send_metrics: when "false" metrics don't get sent;
-  # APP_ENV: when "test" the main script is not executed
-  CONFIG_FILE=${1:-$SCRIPT_DIR/upload_to_s3.config}
-  # shellcheck source=/dev/null
-  source "$CONFIG_FILE"
+    # CONFIG
+    # Variables contained in the config file:
+    #
+    # input_directory: path to the input directory
+    # working directory: path to nfs directory for doing the zipping and sending
+    # processed_directory: path to the directory  of processed files+%
+    # digifeeds_bucket: rclone remote for the digifeeds bucket
+    #
+    # timestamp: used for testing timestamps; should be ommited in production
+    # send_metrics: when "false" metrics don't get sent;
+    # APP_ENV: when "test" the main script is not executed
+    CONFIG_FILE=${1:-$SCRIPT_DIR/upload_to_s3.config}
+    # shellcheck source=/dev/null
+    source "$CONFIG_FILE"
 fi
 if ! input_directory=${input_directory:?}; then exit 1; fi
 if ! processed_directory=${processed_directory:?}; then exit 1; fi
@@ -62,97 +62,105 @@ errors_total=0
 ###########
 
 log_info() {
-  echo "$(date --rfc-3339=seconds) - INFO: $*"
+    echo "$(date --rfc-3339=seconds) - INFO: $*"
 }
 
 log_error() {
-  echo "$(date --rfc-3339=seconds) - ERROR: $*"
+    echo "$(date --rfc-3339=seconds) - ERROR: $*"
 }
 log_debug() {
-  [[ ${DEBUG:-false} == "true" ]] && echo "$(date --rfc-3339=seconds) - DEBUG: $*"
+    [[ ${DEBUG:-false} == "true" ]] && echo "$(date --rfc-3339=seconds) - DEBUG: $*"
 }
 
 #equivalent to ls
 list_files() {
-  local path=$1
-  find "$path" -maxdepth 1 ! -printf '%P\n'
+    local path=$1
+    find "$path" -maxdepth 1 ! -printf '%P\n'
 }
 
 # Gets the last count from a job in the push gateway push gateway
 last_count() {
-  local metric=$1
-  pushgateway_advanced -j $JOB_NAME -q "${metric}"
+    local metric=$1
+    pushgateway_advanced -j $JOB_NAME -q "${metric}"
 }
 
 verify_image_order() {
-  #Sort the array
-  mapfile -t sorted < <(printf '%s\n' "$@" | sort)
+    #Sort the array
+    mapfile -t sorted < <(printf '%s\n' "$@" | sort)
 
-  local cnt=0
-  for arg in "${sorted[@]}"; do
-    cnt=$((cnt + 1))
-    int=${arg:0:8}
-    [ $((10#$int)) != $cnt ] && return 1
-  done
-  return 0
+    local cnt=0
+    for arg in "${sorted[@]}"; do
+        cnt=$((cnt + 1))
+        int=${arg:0:8}
+        [ $((10#$int)) != $cnt ] && return 1
+    done
+    return 0
 }
 
 zip_it() {
-  local barcode_path=$1
-  cd "$barcode_path" || return 1
-  list_files . | awk "$IMGAWK" | xargs zip -rq "$barcode_path".zip
-  local zip_return=$?
-  #Go back to  previous directory; Don't print the output.
-  cd - >/dev/null || return 1
-  return $zip_return
+    local barcode_path=$1
+    cd "$barcode_path" || return 1
+    list_files . | awk "$IMGAWK" | xargs zip -rq "$barcode_path".zip
+    local zip_return=$?
+    #Go back to  previous directory; Don't print the output.
+    cd - >/dev/null || return 1
+    return $zip_return
 }
 
 verify_zip() {
-  local barcode_path=$1
+    local barcode_path=$1
 
-  local files_in_dir
-  if ! files_in_dir=$(list_files "$barcode_path" | awk "$IMGAWK" | sort); then
-    return 1
-  fi
-  local files_in_zip
-  if ! files_in_zip=$(zipinfo -1 "$barcode_path".zip | sort); then
-    return 1
-  fi
+    local files_in_dir
+    if ! files_in_dir=$(list_files "$barcode_path" | awk "$IMGAWK" | sort); then
+        return 1
+    fi
+    local files_in_zip
+    if ! files_in_zip=$(zipinfo -1 "$barcode_path".zip | sort); then
+        return 1
+    fi
 
-  if [ "$files_in_dir" == "$files_in_zip" ]; then
-    return 0
-  else
-    return 1
-  fi
+    if [ "$files_in_dir" == "$files_in_zip" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+clean_working_directory() {
+    local barcode_path=$1
+    rm -r "$barcode_path"
+    if [ -f "$barcode_path".zip ]; then
+        rm "$barcode_path".zip
+    fi
 }
 
 print_metrics() {
-  local fp_current_total=$1
-  local image_order_errors_current_total=$2
-  local upload_errors_current_total=$3
-  local errors_current_total=$4
+    local fp_current_total=$1
+    local image_order_errors_current_total=$2
+    local upload_errors_current_total=$3
+    local errors_current_total=$4
 
-  local fp_metric="${JOB_NAME}_files_processed_total"
-  local fp_last
-  fp_last=$(last_count $fp_metric)
-  local fp_total=$((fp_last + fp_current_total))
+    local fp_metric="${JOB_NAME}_files_processed_total"
+    local fp_last
+    fp_last=$(last_count $fp_metric)
+    local fp_total=$((fp_last + fp_current_total))
 
-  local image_order_errors_metric="${JOB_NAME}_image_order_errors_total"
-  local image_order_errors_last
-  image_order_errors_last=$(last_count $image_order_errors_metric)
-  local image_order_errors_total=$((image_order_errors_last + image_order_errors_current_total))
+    local image_order_errors_metric="${JOB_NAME}_image_order_errors_total"
+    local image_order_errors_last
+    image_order_errors_last=$(last_count $image_order_errors_metric)
+    local image_order_errors_total=$((image_order_errors_last + image_order_errors_current_total))
 
-  local upload_errors_metric="${JOB_NAME}_upload_errors_total"
-  local upload_errors_last
-  upload_errors_last=$(last_count $upload_errors_metric)
-  local upload_errors_total=$((upload_errors_last + upload_errors_current_total))
+    local upload_errors_metric="${JOB_NAME}_upload_errors_total"
+    local upload_errors_last
+    upload_errors_last=$(last_count $upload_errors_metric)
+    local upload_errors_total=$((upload_errors_last + upload_errors_current_total))
 
-  local errors_metric="${JOB_NAME}_errors_total"
-  local errors_last
-  errors_last=$(last_count $errors_metric)
-  local errors_total=$((errors_last + errors_current_total))
+    local errors_metric="${JOB_NAME}_errors_total"
+    local errors_last
+    errors_last=$(last_count $errors_metric)
+    local errors_total=$((errors_last + errors_current_total))
 
-  cat <<EOMETRICS
+    cat <<EOMETRICS
 # HELP ${fp_metric} Count of digifeeds zip files sent to S3
 # TYPE ${fp_metric} counter
 $fp_metric $fp_total
@@ -169,109 +177,116 @@ EOMETRICS
 }
 
 main() {
-  TIMESTAMP=${timestamp:-$(date +%F_%H-%M-%S)} #YYY-MM-DD_hh-mm-ss
+    TIMESTAMP=${timestamp:-$(date +%F_%H-%M-%S)} #YYY-MM-DD_hh-mm-ss
 
-  #This is so that the script works on empty directories.
-  shopt -s nullglob
+    #This is so that the script works on empty directories.
+    shopt -s nullglob
 
-  for barcode_path in "${input_directory}"/*/; do
-    local barcode
-    barcode=$(basename "${barcode_path%%/}")
-    working_barcode_path="${working_directory}/$barcode"
+    for barcode_path in "${input_directory}"/*/; do
+        local barcode
+        barcode=$(basename "${barcode_path%%/}")
+        working_barcode_path="${working_directory}/$barcode"
 
-    log_info "Processing $barcode"
+        log_info "Processing $barcode"
 
-    log_debug "Copying $barcode to working directory"
+        log_debug "Copying $barcode to working directory"
 
-    if ! cp -r "$barcode_path" "$working_barcode_path"; then
-      log_error "Copying $barcode to working directory failed"
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        if ! cp -r "$barcode_path" "$working_barcode_path"; then
+            log_error "Copying $barcode to working directory failed"
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Verifying image order $barcode"
-    #8 digits, ends in .tif or .jp2
-    filter_regex='[[:digit:]]{8}\.tif$|[[:digit:]]{8}\.jp2$'
-    local image_list
-    image_list=$(list_files "$working_barcode_path" | grep -E "$filter_regex")
-    if ! verify_image_order "$image_list"; then
-      log_error "Image order incorrect for $barcode"
-      image_order_errors_total=$((image_order_errors_total + 1))
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_debug "Verifying image order $barcode"
+        #8 digits, ends in .tif or .jp2
+        filter_regex='[[:digit:]]{8}\.tif$|[[:digit:]]{8}\.jp2$'
+        local image_list
+        image_list=$(list_files "$working_barcode_path" | grep -E "$filter_regex")
+        if ! verify_image_order "$image_list"; then
+            log_error "Image order incorrect for $barcode"
+            clean_working_directory "$working_barcode_path"
+            image_order_errors_total=$((image_order_errors_total + 1))
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Zipping $barcode"
-    if ! zip_it "$working_barcode_path"; then
-      log_error "Failed to zip $barcode"
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_debug "Zipping $barcode"
+        if ! zip_it "$working_barcode_path"; then
+            log_error "Failed to zip $barcode"
+            clean_working_directory "$working_barcode_path"
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Verifying zip of $barcode"
-    if ! verify_zip "$working_barcode_path"; then
-      log_error "$barcode.zip does not contain the correct files"
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_debug "Verifying zip of $barcode"
+        if ! verify_zip "$working_barcode_path"; then
+            log_error "$barcode.zip does not contain the correct files"
+            clean_working_directory "$working_barcode_path"
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Sending $barcode to S3"
-    if ! rclone copy "$working_barcode_path".zip "$digifeeds_bucket":; then
-      log_error "Failed to copy $barcode"
-      upload_errors_total=$((upload_errors_total + 1))
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_debug "Sending $barcode to S3"
+        if ! rclone copy "$working_barcode_path".zip "$digifeeds_bucket":; then
+            log_error "Failed to copy $barcode"
+            clean_working_directory "$working_barcode_path"
+            upload_errors_total=$((upload_errors_total + 1))
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Verifying barcode in S3"
-    if ! rclone check "$working_barcode_path".zip "$digifeeds_bucket":; then
-      log_error "$barcode not found in S3"
-      upload_errors_total=$((upload_errors_total + 1))
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_debug "Verifying barcode in S3"
+        if ! rclone check "$working_barcode_path".zip "$digifeeds_bucket":; then
+            log_error "$barcode not found in S3"
+            clean_working_directory "$working_barcode_path"
+            upload_errors_total=$((upload_errors_total + 1))
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_info "Moving $barcode to processed"
-    log_debug "Copying ${barcode}.zip to processed"
-    if ! cp "$working_barcode_path".zip "$processed_directory"/"${TIMESTAMP}"_"${barcode}".zip; then
-      log_error "Failed to copy $barcode.zip to processed"
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_info "Moving $barcode to processed"
+        log_debug "Copying ${barcode}.zip to processed"
+        if ! cp "$working_barcode_path".zip "$processed_directory"/"${TIMESTAMP}"_"${barcode}".zip; then
+            log_error "Failed to copy $barcode.zip to processed"
+            clean_working_directory "$working_barcode_path"
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Deleting ${working_barcode_path}.zip"
-    rm "$working_barcode_path".zip
+        log_debug "Deleting ${working_barcode_path}.zip"
+        rm "$working_barcode_path".zip
 
-    log_debug "Copying ${barcode} to processed"
-    if ! cp -r "$working_barcode_path" "$processed_directory"/"${TIMESTAMP}"_"${barcode}"; then
-      log_error "Failed to copy $barcode to processed"
-      errors_total=$((errors_total + 1))
-      continue
-    fi
+        log_debug "Copying ${barcode} to processed"
+        if ! cp -r "$working_barcode_path" "$processed_directory"/"${TIMESTAMP}"_"${barcode}"; then
+            log_error "Failed to copy $barcode to processed"
+            clean_working_directory "$working_barcode_path"
+            errors_total=$((errors_total + 1))
+            continue
+        fi
 
-    log_debug "Deleting ${working_barcode_path}"
-    rm -r "$working_barcode_path"
-    log_debug "Deleting ${barcode_path}"
-    rm -r "$barcode_path"
+        log_debug "Deleting ${working_barcode_path}"
+        rm -r "$working_barcode_path"
+        log_debug "Deleting ${barcode_path}"
+        rm -r "$barcode_path"
 
-    files_processed_total=$((files_processed_total + 1))
-  done
+        files_processed_total=$((files_processed_total + 1))
+    done
 
-  log_info "Total files processed: $files_processed_total"
-  log_info "Total errors image order: $image_order_errors_total "
-  log_info "Total errors uploading to S3: $upload_errors_total"
-  log_info "Total errors: $errors_total"
+    log_info "Total files processed: $files_processed_total"
+    log_info "Total errors image order: $image_order_errors_total "
+    log_info "Total errors uploading to S3: $upload_errors_total"
+    log_info "Total errors: $errors_total"
 }
 
 if [[ $APP_ENV != "test" ]]; then
 
-  log_info "=====Start $(date)====="
+    log_info "=====Start $(date)====="
 
-  main
+    main
 
-  if [ "$send_metrics" != "false" ]; then
-    print_metrics $files_processed_total $image_order_errors_total $upload_errors_total $errors_total | /usr/local/bin/pushgateway_advanced -j $JOB_NAME
-    /usr/local/bin/pushgateway -j $JOB_NAME -b "$START_TIME"
-  fi
-  log_info "=====End $(date)====="
+    if [ "$send_metrics" != "false" ]; then
+        print_metrics $files_processed_total $image_order_errors_total $upload_errors_total $errors_total | /usr/local/bin/pushgateway_advanced -j $JOB_NAME
+        /usr/local/bin/pushgateway -j $JOB_NAME -b "$START_TIME"
+    fi
+    log_info "=====End $(date)====="
 fi

--- a/bin/digifeeds/upload_to_s3_test.sh
+++ b/bin/digifeeds/upload_to_s3_test.sh
@@ -249,9 +249,9 @@ teardown() {
     shellmock config pushgateway_advanced 0 <<<5
     run print_metrics 1 2 3 4
     assert_output --partial "aim_digifeeds_upload_to_aws_files_processed_total 6"
-    assert_output --partial "aim_digifeeds_upload_to_aws_image_order_errors_total 7"
-    assert_output --partial "aim_digifeeds_upload_to_aws_upload_errors_total 8"
-    assert_output --partial "aim_digifeeds_upload_to_aws_errors_total 9"
+    assert_output --partial "aim_digifeeds_upload_to_aws_image_order_errors 2"
+    assert_output --partial "aim_digifeeds_upload_to_aws_upload_errors 3"
+    assert_output --partial "aim_digifeeds_upload_to_aws_errors 4"
     shellmock assert expectations pushgateway_advanced
 
 }

--- a/bin/digifeeds/upload_to_s3_test.sh
+++ b/bin/digifeeds/upload_to_s3_test.sh
@@ -5,244 +5,266 @@ bats_load_library bats-assert
 bats_load_library bats-file
 
 setup() {
-  load "$SHELLMOCK_PATH"
-  SCRATCH_PATH="/tmp/upload_to_s3"
-  SUBJECT=main
+    load "$SHELLMOCK_PATH"
+    SCRATCH_PATH="/tmp/upload_to_s3"
+    SUBJECT=main
 
-  mkdir $SCRATCH_PATH
+    mkdir $SCRATCH_PATH
 
-  INPUT_DIR=$SCRATCH_PATH/input
-  WORKING_DIR=$SCRATCH_PATH/working
-  PROCESSED_DIR=$SCRATCH_PATH/processed
+    INPUT_DIR=$SCRATCH_PATH/input
+    WORKING_DIR=$SCRATCH_PATH/working
+    PROCESSED_DIR=$SCRATCH_PATH/processed
 
-  BARCODE_1="30000000189012"
-  BARCODE_2="40000000189012"
-  TIMESTAMP="YYYY-MM-DD_hh-mm-ss"
+    BARCODE_1="30000000189012"
+    BARCODE_2="40000000189012"
+    TIMESTAMP="YYYY-MM-DD_hh-mm-ss"
 
-  mkdir $INPUT_DIR
-  mkdir $PROCESSED_DIR
-  mkdir $WORKING_DIR
+    mkdir $INPUT_DIR
+    mkdir $PROCESSED_DIR
+    mkdir $WORKING_DIR
 
-  mkdir $INPUT_DIR/$BARCODE_1
-  touch $INPUT_DIR/$BARCODE_1/00000001.tif
-  touch $INPUT_DIR/$BARCODE_1/00000002.jp2
-  touch $INPUT_DIR/$BARCODE_1/checksum.md5
-  touch $INPUT_DIR/$BARCODE_1/Thumbs.db
-  touch $INPUT_DIR/$BARCODE_1/some_other_file.tif
+    mkdir $INPUT_DIR/$BARCODE_1
+    touch $INPUT_DIR/$BARCODE_1/00000001.tif
+    touch $INPUT_DIR/$BARCODE_1/00000002.jp2
+    touch $INPUT_DIR/$BARCODE_1/checksum.md5
+    touch $INPUT_DIR/$BARCODE_1/Thumbs.db
+    touch $INPUT_DIR/$BARCODE_1/some_other_file.tif
 
-  mkdir $INPUT_DIR/$BARCODE_2
-  touch $INPUT_DIR/$BARCODE_2/00000001.tif
+    mkdir $INPUT_DIR/$BARCODE_2
+    touch $INPUT_DIR/$BARCODE_2/00000001.tif
 
-  ## Config that's in main.
-  export input_directory="$INPUT_DIR"
-  export processed_directory="$PROCESSED_DIR"
-  export working_directory="$WORKING_DIR"
-  export digifeeds_bucket="digifeeds_bucket"
-  export timestamp=$TIMESTAMP
-  export send_metrics="false"
-  export APP_ENV="test"
+    ## Config that's in main.
+    export input_directory="$INPUT_DIR"
+    export processed_directory="$PROCESSED_DIR"
+    export working_directory="$WORKING_DIR"
+    export digifeeds_bucket="digifeeds_bucket"
+    export timestamp=$TIMESTAMP
+    export send_metrics="false"
+    export APP_ENV="test"
 
-  load "$BATS_TEST_DIRNAME/upload_to_s3.sh"
+    load "$BATS_TEST_DIRNAME/upload_to_s3.sh"
 }
 
 teardown() {
-  rm -r "$SCRATCH_PATH"
+    rm -r "$SCRATCH_PATH"
 }
 
 @test "exits without input_directory" {
-  unset input_directory
-  run "${BATS_TEST_DIRNAME}/upload_to_s3.sh"
-  assert_failure
+    unset input_directory
+    run "${BATS_TEST_DIRNAME}/upload_to_s3.sh"
+    assert_failure
 }
 @test "exits without processed_directory" {
-  unset processed_directory
-  run "${BATS_TEST_DIRNAME}/upload_to_s3.sh"
-  assert_failure
+    unset processed_directory
+    run "${BATS_TEST_DIRNAME}/upload_to_s3.sh"
+    assert_failure
 }
 @test "exits without digifeeds_bucket" {
-  unset digifeeds_bucket
-  run "${BATS_TEST_DIRNAME}/upload_to_s3.sh"
-  assert_failure
+    unset digifeeds_bucket
+    run "${BATS_TEST_DIRNAME}/upload_to_s3.sh"
+    assert_failure
 }
 
 @test "It Works" {
-  shellmock new rclone
-  shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
-  shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
-  run $SUBJECT
+    shellmock new rclone
+    shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
+    shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
+    run $SUBJECT
 
-  assert_success
+    assert_success
 
-  assert_file_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_1}".zip
-  assert_file_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_2}".zip
+    assert_file_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_1}".zip
+    assert_file_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_2}".zip
 
-  assert_dir_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_1}"
-  assert_dir_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_2}"
-  shellmock assert expectations rclone
+    assert_dir_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_1}"
+    assert_dir_exists "$PROCESSED_DIR"/"${TIMESTAMP}"_"${BARCODE_2}"
+    shellmock assert expectations rclone
 }
 
 @test "It filters the appropriate files" {
-  shellmock new rclone
-  shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
-  shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
+    shellmock new rclone
+    shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
+    shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
 
-  run $SUBJECT
-  cd "$BATS_TEST_TMPDIR"
-  mv "$PROCESSED_DIR/${TIMESTAMP}_${BARCODE_1}.zip" ./
-  unzip -q "${TIMESTAMP}_${BARCODE_1}.zip"
-  assert_file_exists '00000001.tif'
-  assert_file_exists '00000002.jp2'
-  assert_file_exists 'checksum.md5'
-  assert_file_not_exists 'Thumbs.db'
-  assert_file_not_exists 'some_other_file.tif'
+    run $SUBJECT
+    cd "$BATS_TEST_TMPDIR"
+    mv "$PROCESSED_DIR/${TIMESTAMP}_${BARCODE_1}.zip" ./
+    unzip -q "${TIMESTAMP}_${BARCODE_1}.zip"
+    assert_file_exists '00000001.tif'
+    assert_file_exists '00000002.jp2'
+    assert_file_exists 'checksum.md5'
+    assert_file_not_exists 'Thumbs.db'
+    assert_file_not_exists 'some_other_file.tif'
 
-  shellmock assert expectations rclone
+    shellmock assert expectations rclone
 }
 
 # This test shows that `shopt -s  nullglob` in necessary`
 @test "Emtpy input directory works" {
-  rm -r "${INPUT_DIR:?}/${BARCODE_1:?}"
-  rm -r "${INPUT_DIR:?}/${BARCODE_2:?}"
+    rm -r "${INPUT_DIR:?}/${BARCODE_1:?}"
+    rm -r "${INPUT_DIR:?}/${BARCODE_2:?}"
 
-  run $SUBJECT
-  assert_success
+    run $SUBJECT
+    assert_success
 }
 
 @test "verify_image_order sucess" {
-  run verify_image_order 00000001.tif 00000003.jp2 00000002.tif
-  assert_success
+    run verify_image_order 00000001.tif 00000003.jp2 00000002.tif
+    assert_success
 }
 
 @test "verify_image_order failure" {
-  run verify_image_order 00000001.tif 00000003.tif 00000004.jp2
-  assert_failure
+    run verify_image_order 00000001.tif 00000003.tif 00000004.jp2
+    assert_failure
 }
 
 @test "Failed image order" {
-  shellmock new rclone
-  shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
-  shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
-  touch "$INPUT_DIR"/"$BARCODE_1"/00000004.jp2
-  run $SUBJECT
-  assert_output --partial "ERROR: Image order incorrect for $BARCODE_1"
-  assert_output --partial "INFO: Total files processed: 1"
-  assert_output --partial "INFO: Total errors: 1"
-  assert_output --partial "INFO: Total errors image order: 1"
-  assert_output --partial "INFO: Total errors uploading to S3: 0"
-  shellmock assert expectations rclone
+    shellmock new rclone
+    shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
+    shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
+    touch "$INPUT_DIR"/"$BARCODE_1"/00000004.jp2
+    run $SUBJECT
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_1"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_1.zip"
+    assert_output --partial "ERROR: Image order incorrect for $BARCODE_1"
+    assert_output --partial "INFO: Total files processed: 1"
+    assert_output --partial "INFO: Total errors: 1"
+    assert_output --partial "INFO: Total errors image order: 1"
+    assert_output --partial "INFO: Total errors uploading to S3: 0"
+    shellmock assert expectations rclone
 }
 
 @test "Failed zip" {
-  shellmock new zip
-  shellmock config zip 1
-  run $SUBJECT
-  assert_output --partial "ERROR: Failed to zip $BARCODE_1"
-  assert_output --partial "ERROR: Failed to zip $BARCODE_2"
-  assert_output --partial "INFO: Total files processed: 0"
-  assert_output --partial "INFO: Total errors image order: 0"
-  assert_output --partial "INFO: Total errors: 2"
-  assert_output --partial "INFO: Total errors uploading to S3: 0"
-  shellmock assert expectations zip
+    shellmock new zip
+    shellmock config zip 1
+    run $SUBJECT
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_1"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_1.zip"
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_2"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_2.zip"
+    assert_output --partial "ERROR: Failed to zip $BARCODE_1"
+    assert_output --partial "ERROR: Failed to zip $BARCODE_2"
+    assert_output --partial "INFO: Total files processed: 0"
+    assert_output --partial "INFO: Total errors image order: 0"
+    assert_output --partial "INFO: Total errors: 2"
+    assert_output --partial "INFO: Total errors uploading to S3: 0"
+    shellmock assert expectations zip
 }
 
 @test "Failed copy records error and moves on" {
-  shellmock new rclone
-  shellmock config rclone 1 1:copy regex-3:^digifeeds_bucket: <<<"Rclone error mock: Failed to copy"
-  run $SUBJECT
-  assert_output --partial "ERROR: Failed to copy $BARCODE_1"
-  assert_output --partial "ERROR: Failed to copy $BARCODE_2"
-  assert_output --partial "INFO: Total files processed: 0"
-  assert_output --partial "INFO: Total errors image order: 0"
-  assert_output --partial "INFO: Total errors: 2"
-  assert_output --partial "INFO: Total errors uploading to S3: 2"
-  shellmock assert expectations rclone
+    shellmock new rclone
+    shellmock config rclone 1 1:copy regex-3:^digifeeds_bucket: <<<"Rclone error mock: Failed to copy"
+    run $SUBJECT
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_1"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_1.zip"
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_2"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_2.zip"
+    assert_output --partial "ERROR: Failed to copy $BARCODE_1"
+    assert_output --partial "ERROR: Failed to copy $BARCODE_2"
+    assert_output --partial "INFO: Total files processed: 0"
+    assert_output --partial "INFO: Total errors image order: 0"
+    assert_output --partial "INFO: Total errors: 2"
+    assert_output --partial "INFO: Total errors uploading to S3: 2"
+    shellmock assert expectations rclone
 }
 
 @test "Failed on S3 verification and moves on" {
-  shellmock new rclone
-  shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
-  shellmock config rclone 1 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
-  run $SUBJECT
-  assert_output --partial "ERROR: $BARCODE_1 not found in S3"
-  assert_output --partial "ERROR: $BARCODE_2 not found in S3"
-  assert_output --partial "INFO: Total files processed: 0"
-  assert_output --partial "INFO: Total errors image order: 0"
-  assert_output --partial "INFO: Total errors: 2"
-  assert_output --partial "INFO: Total errors uploading to S3: 2"
-  shellmock assert expectations rclone
+    shellmock new rclone
+    shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
+    shellmock config rclone 1 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
+    run $SUBJECT
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_1"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_1.zip"
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_2"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_2.zip"
+    assert_output --partial "ERROR: $BARCODE_1 not found in S3"
+    assert_output --partial "ERROR: $BARCODE_2 not found in S3"
+    assert_output --partial "INFO: Total files processed: 0"
+    assert_output --partial "INFO: Total errors image order: 0"
+    assert_output --partial "INFO: Total errors: 2"
+    assert_output --partial "INFO: Total errors uploading to S3: 2"
+    shellmock assert expectations rclone
 }
 @test "Fails on copying barcode folder to working directory and moves on" {
-  shellmock new cp
-  shellmock config cp 1 regex-2:"$INPUT_DIR" <<<"Error"
-  run $SUBJECT
-  assert_output --partial "ERROR: Copying $BARCODE_1 to working directory failed"
-  assert_output --partial "ERROR: Copying $BARCODE_2 to working directory failed"
-  assert_output --partial "INFO: Total files processed: 0"
-  assert_output --partial "INFO: Total errors image order: 0"
-  assert_output --partial "INFO: Total errors: 2"
-  assert_output --partial "INFO: Total errors uploading to S3: 0"
-  shellmock assert expectations cp
+    shellmock new cp
+    shellmock config cp 1 regex-2:"$INPUT_DIR" <<<"Error"
+    run $SUBJECT
+    assert_output --partial "ERROR: Copying $BARCODE_1 to working directory failed"
+    assert_output --partial "ERROR: Copying $BARCODE_2 to working directory failed"
+    assert_output --partial "INFO: Total files processed: 0"
+    assert_output --partial "INFO: Total errors image order: 0"
+    assert_output --partial "INFO: Total errors: 2"
+    assert_output --partial "INFO: Total errors uploading to S3: 0"
+    shellmock assert expectations cp
 }
 
 @test "Fails on copying zip to processed directory and moves on" {
-  shellmock new rclone
-  shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
-  shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
-  cp -r "$INPUT_DIR"/* "$WORKING_DIR"
-  shellmock new cp
-  shellmock config cp 0 regex-2:"$INPUT_DIR"
-  shellmock config cp 1 regex-2:.zip <<<"Error"
-  run $SUBJECT
-  assert_output --partial "ERROR: Failed to copy ${BARCODE_1}.zip to processed"
-  assert_output --partial "ERROR: Failed to copy ${BARCODE_2}.zip to processed"
-  assert_output --partial "INFO: Total files processed: 0"
-  assert_output --partial "INFO: Total errors image order: 0"
-  assert_output --partial "INFO: Total errors: 2"
-  assert_output --partial "INFO: Total errors uploading to S3: 0"
-  shellmock assert expectations cp
-  shellmock assert expectations rclone
+    shellmock new rclone
+    shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
+    shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
+    cp -r "$INPUT_DIR"/* "$WORKING_DIR"
+    shellmock new cp
+    shellmock config cp 0 regex-2:"$INPUT_DIR"
+    shellmock config cp 1 regex-2:.zip <<<"Error"
+    run $SUBJECT
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_1"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_1.zip"
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_2"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_2.zip"
+    assert_output --partial "ERROR: Failed to copy ${BARCODE_1}.zip to processed"
+    assert_output --partial "ERROR: Failed to copy ${BARCODE_2}.zip to processed"
+    assert_output --partial "INFO: Total files processed: 0"
+    assert_output --partial "INFO: Total errors image order: 0"
+    assert_output --partial "INFO: Total errors: 2"
+    assert_output --partial "INFO: Total errors uploading to S3: 0"
+    shellmock assert expectations cp
+    shellmock assert expectations rclone
 }
 @test "Fails on copying working folder to processed directory and moves on" {
-  shellmock new rclone
-  shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
-  shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
-  cp -r "$INPUT_DIR"/* "$WORKING_DIR"
-  shellmock new cp
-  shellmock config cp 0 regex-2:"$INPUT_DIR"
-  shellmock config cp 0 regex-2:.zip
-  shellmock config cp 1 <<<"Error"
-  run $SUBJECT
-  assert_output --partial "ERROR: Failed to copy ${BARCODE_1} to processed"
-  assert_output --partial "ERROR: Failed to copy ${BARCODE_2} to processed"
-  assert_output --partial "INFO: Total files processed: 0"
-  assert_output --partial "INFO: Total errors image order: 0"
-  assert_output --partial "INFO: Total errors: 2"
-  assert_output --partial "INFO: Total errors uploading to S3: 0"
-  shellmock assert expectations cp
-  shellmock assert expectations rclone
+    shellmock new rclone
+    shellmock config rclone 0 1:copy regex-3:^digifeeds_bucket:
+    shellmock config rclone 0 1:check regex-2:"$WORKING_DIR" regex-3:^digifeeds_bucket:
+    cp -r "$INPUT_DIR"/* "$WORKING_DIR"
+    shellmock new cp
+    shellmock config cp 0 regex-2:"$INPUT_DIR"
+    shellmock config cp 0 regex-2:.zip
+    shellmock config cp 1 <<<"Error"
+    run $SUBJECT
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_1"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_1.zip"
+    assert_dir_not_exists "$WORKING_DIR/$BARCODE_2"
+    assert_file_not_exists "$WORKING_DIR/$BARCODE_2.zip"
+    assert_output --partial "ERROR: Failed to copy ${BARCODE_1} to processed"
+    assert_output --partial "ERROR: Failed to copy ${BARCODE_2} to processed"
+    assert_output --partial "INFO: Total files processed: 0"
+    assert_output --partial "INFO: Total errors image order: 0"
+    assert_output --partial "INFO: Total errors: 2"
+    assert_output --partial "INFO: Total errors uploading to S3: 0"
+    shellmock assert expectations cp
+    shellmock assert expectations rclone
 }
 
 @test "print_metrics" {
-  shellmock new pushgateway_advanced
-  shellmock config pushgateway_advanced 0 <<<5
-  run print_metrics 1 2 3 4
-  assert_output --partial "aim_digifeeds_upload_to_aws_files_processed_total 6"
-  assert_output --partial "aim_digifeeds_upload_to_aws_image_order_errors_total 7"
-  assert_output --partial "aim_digifeeds_upload_to_aws_upload_errors_total 8"
-  assert_output --partial "aim_digifeeds_upload_to_aws_errors_total 9"
-  shellmock assert expectations pushgateway_advanced
+    shellmock new pushgateway_advanced
+    shellmock config pushgateway_advanced 0 <<<5
+    run print_metrics 1 2 3 4
+    assert_output --partial "aim_digifeeds_upload_to_aws_files_processed_total 6"
+    assert_output --partial "aim_digifeeds_upload_to_aws_image_order_errors_total 7"
+    assert_output --partial "aim_digifeeds_upload_to_aws_upload_errors_total 8"
+    assert_output --partial "aim_digifeeds_upload_to_aws_errors_total 9"
+    shellmock assert expectations pushgateway_advanced
 
 }
 
 @test "verify_zip success" {
-  zip_it "$INPUT_DIR"/"$BARCODE_1"
-  run verify_zip "$INPUT_DIR"/"$BARCODE_1"
-  assert_success
+    zip_it "$INPUT_DIR"/"$BARCODE_1"
+    run verify_zip "$INPUT_DIR"/"$BARCODE_1"
+    assert_success
 }
 
 @test "verify_zip fail" {
-  zip_it "$INPUT_DIR"/"$BARCODE_2"
-  mv "$INPUT_DIR"/"$BARCODE_2".zip "$INPUT_DIR"/"$BARCODE_1".zip
-  run verify_zip "$INPUT_DIR"/"$BARCODE_1"
-  assert_failure
+    zip_it "$INPUT_DIR"/"$BARCODE_2"
+    mv "$INPUT_DIR"/"$BARCODE_2".zip "$INPUT_DIR"/"$BARCODE_1".zip
+    run verify_zip "$INPUT_DIR"/"$BARCODE_1"
+    assert_failure
 }


### PR DESCRIPTION
The upload_to_s3 script was not cleaning up the working directory when there were errors. This was causing problems when running the script a second time when there were existing files in the working directory.

In this PR, when an iteration of the loop errors, the corresponding working directory and zip file are cleaned up in addition to logging the error.

The error counter metric was hard to alert on, so it's been changed to a gauge instead. Files processed is still a counter.